### PR TITLE
Bump com.android.tools.build:gradle from 7.3.1 to 8.2.0 in /android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.14'
     }


### PR DESCRIPTION
Bumps com.android.tools.build:gradle from 7.3.1 to 8.2.0.

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-type: direct:production update-type: version-update:semver-major ...