### PR TITLE
Bump com.google.android.gms:play-services-ads in /android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -68,6 +68,6 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:30.1.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
-    implementation 'com.google.android.gms:play-services-ads:21.3.0'
+    implementation 'com.google.android.gms:play-services-ads:22.6.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
 }


### PR DESCRIPTION
Bumps com.google.android.gms:play-services-ads from 21.3.0 to 22.6.0.

---
updated-dependencies:
- dependency-name: com.google.android.gms:play-services-ads dependency-type: direct:production update-type: version-update:semver-major ...