### PR TITLE
Bump com.google.firebase:firebase-bom from 30.1.0 to 32.7.0 in /android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,7 +65,7 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation platform('com.google.firebase:firebase-bom:30.1.0')
+    implementation platform('com.google.firebase:firebase-bom:32.7.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
     implementation 'com.google.android.gms:play-services-ads:21.3.0'


### PR DESCRIPTION
Bumps com.google.firebase:firebase-bom from 30.1.0 to 32.7.0.

---
updated-dependencies:
- dependency-name: com.google.firebase:firebase-bom dependency-type: direct:production update-type: version-update:semver-major ...