### PR TITLE
Bump com.google.gms:google-services from 4.3.14 to 4.4.0 in /android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.14'
+        classpath 'com.google.gms:google-services:4.4.0'
     }
 }
 


### PR DESCRIPTION
Bumps com.google.gms:google-services from 4.3.14 to 4.4.0.

---
updated-dependencies:
- dependency-name: com.google.gms:google-services dependency-type: direct:production update-type: version-update:semver-minor ...